### PR TITLE
RKDArtists: update endpoint

### DIFF
--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -122,7 +122,7 @@ class NdeTermsDataTypeFactory implements FactoryInterface
         ],
         'valuesuggest:ndeterms:rkdartists' => [
             'label' => 'NDE: RKDartists', // @translate
-            'source' => 'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql',
+            'source' => 'https://data.rkd.nl/rkdartists',
         ],
         'valuesuggest:ndeterms:stcn' => [
             'label' => 'NDE: STCN: printers', // @translate


### PR DESCRIPTION
This dataset has been [removed from the NDE instance](https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/) and is now available [directly at the RKD](https://rkd.triply.cc/rkd/RKD-SDO-Knowledge-Graph).

Checked the returned identifiers are still the same.