### PR TITLE
New release with added source and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # NDE Termennetwerk
 
-An [Omeka S](https://omeka.org/s/) module that adds NDE (Netwerk Digitaal Erfgoed)
-Termennetwerk to the Value Suggest module.
+An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https://termennetwerk.netwerkdigitaalerfgoed.nl/en) (Dutch Digital Heritage Network) to the Value Suggest module.
 
 ### [NDE Termennetwerk](https://termennetwerk.netwerkdigitaalerfgoed.nl/)
 
@@ -17,6 +16,7 @@ Termennetwerk to the Value Suggest module.
 - Cultural-Historical Thesaurus
 - Cultural-Historical Thesaurus - Materials
 - Cultural-Historical Thesaurus - Styles and periods
+- Dutch thesaurus of author names (NTA)
 - EuroVoc - thesaurus of the European Union
 - GeoNames: gepgraphical names in the Netherlands, Belgium and Germany
 - GTAA: classification
@@ -33,10 +33,10 @@ Termennetwerk to the Value Suggest module.
 - Muziekschatten: subjects
 - Muziekschatten: performance mediums
 - Muziekschatten: persons
-- Dutch thesaurus of author names
+- National Monuments Register RCE
 - RKDartists
 - STCN: printers
-- streets in Gouda
+- Streets in Gouda
 - Thesaurus National Museum of World Cultures
 - Thesaurus Second World War Netherlands
 - Wikidata: all entities

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,8 +1,8 @@
 [info]
-version = "1.1.0"
+version = "1.2.0"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
-description = "Adds NDE (Netwerk Digitaal Erfgoed) Termennetwerk to the Value Suggest module"
+description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"
 author = "Omeka Team"
 author_link = "https://omeka.org/"
 configurable = false

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -132,7 +132,7 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: Thesaurus National Museum of World Cultures', // @translate
             'source' => 'https://data.netwerkdigitaalerfgoed.nl/NMVW/thesaurus/sparql',
         ],
-        'valuesuggest:ndeterms:ttwn' => [
+        'valuesuggest:ndeterms:tswwnl' => [
             'label' => 'NDE: Thesaurus Second World War Netherlands', // @translate
             'source' => 'https://data.niod.nl/PoolParty/sparql/WO2_Thesaurus',
         ],

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -53,7 +53,7 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'source' => 'http://publications.europa.eu/webapi/rdf/sparql#eurovoc',
         ],
         'valuesuggest:ndeterms:geonames' => [
-            'label' => 'NDE: GeoNames: gepgraphical names in the Netherlands, Belgium and Germany', // @translate
+            'label' => 'NDE: GeoNames: geographical names in the Netherlands, Belgium and Germany', // @translate
             'source' => 'https://demo.netwerkdigitaalerfgoed.nl/geonames',
         ],
         'valuesuggest:ndeterms:gtm' => [

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -164,6 +164,10 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: Colonial Past', // @translate
             'source' => 'https://data.cultureelerfgoed.nl/PoolParty/sparql/koloniaalverleden',
         ],
+        'valuesuggest:ndeterms:rcemon' => [
+            'label' => 'NDE: National Monuments Register RCE', // @translate
+            'source' => 'https://linkeddata.cultureelerfgoed.nl/cho-kennis/id/rijksmonument/',
+        ],
     ];
 
     public function __invoke(ContainerInterface $services, $requestedName, array $options = null)


### PR DESCRIPTION
- [Added source: National Monuments Register RCE](https://github.com/omeka-s-modules/NdeTermennetwerk/issues/9)
- [Fixed typo in resource name](https://github.com/omeka-s-modules/NdeTermennetwerk/issues/8)
- [Fixed duplicate identifier which leads to unusable term resource](https://github.com/omeka-s-modules/NdeTermennetwerk/issues/7)
- Changes text in README to use English name "Network of Terms" in addition to Dutch name "Termennetwerk"
- Updated to version 1.2.0