### PR TITLE
Release 1.4 (added NDE terminology sources)

### DIFF
--- a/AddSource.md
+++ b/AddSource.md
@@ -76,7 +76,7 @@ The (English) name of the new source should be added to the list of this README.
 
 ## 5 - Update version in [config/module.ini](config/module.ini)
 
-The file config/module.ini contains the versionnumber of the module. When new terminology sources are added the minor number of the version should be incremented.
+The file config/module.ini contains the versionnumber of the module. When new terminology sources are added the patch level of the version should be incremented. Upon release the patch number should be set to 0 and the minor version number should be increased.
 
 ## 6 - Update language strings
 

--- a/AddSource.md
+++ b/AddSource.md
@@ -1,0 +1,84 @@
+# Adding a newly available Network of Terms source
+
+In the current implementation of the NdeTermennetwerk module the available sources are hardcoded.
+
+The [Network of Terms](https://termennetwerk.netwerkdigitaalerfgoed.nl/en) (Termennetwerk) is an services which gives standardized access to a variety of durable terminology sources. The service is maintained by the Cultural Heritage Agency of the Netherlands ([RCE](https://english.cultureelerfgoed.nl/)). When there is a demand for a source to be added and this source is available via SPARQL and is well maintained, the RCE can add a source.
+
+The software, query definitions and catalog of services are maintained via the [Network of Terms Github](https://github.com/netwerk-digitaal-erfgoed/network-of-terms/tree/master/packages/network-of-terms-catalog/catalog/datasets).
+
+Via the [GraphQL API of the Network of Terms](https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphiql), the list of sources can be retrieved in a standardized way:
+
+```graphql
+query Sources {
+  sources {
+    uri
+    name
+    creators {
+      alternateName
+    }
+  }
+}
+```
+
+To make a newly added terminology source available to this module, the following files have to be edited and after testing in a development environment they should be provided to this repo via a pull request.
+
+## 1 - Gather information about new terminology source
+
+Lookup the relevant definition file (dataset) in the [catalog](https://github.com/netwerk-digitaal-erfgoed/network-of-terms/tree/master/packages/network-of-terms-catalog/catalog/datasets). 
+
+For example, [rtf-personen.jsonld](https://github.com/netwerk-digitaal-erfgoed/network-of-terms/blob/master/packages/network-of-terms-catalog/catalog/datasets/rtf-personen.jsonld):
+```json
+{
+  "@context": "https://schema.org",
+  "@id": "https://fryslan.regiotermen.nl/personen",
+  "@type": "Dataset",
+  "name": [
+    {
+      "@language": "en",
+      "@value": "Regiotermen Fryslân: Persons"
+    },
+    {
+      "@language": "nl",
+      "@value": "Regiotermen Fryslân: Personen"
+    }
+  ],
+  ...
+  "distribution": [
+    {
+      "@id": "https://graph.friesland.regiotermen.nl/repositories/friese_thesaurus",
+      ...
+    }
+  ]
+}
+```
+Take note of the English name of the Dataset (to be used as `label`) and the (persistent) @id of the distribution of the dataset (to be used as `source`).
+
+## 2 - Update [src/Service/NdeTermsDataTypeFactory.php](src/Service/NdeTermsDataTypeFactory.php)
+
+The `$types` array in the src/Service/NdeTermsDataTypeFactory.php file should be expanded with an entry like:
+
+```php
+        'valuesuggest:ndeterms:rtf' => [
+            'label' => 'Regiotermen Fryslân: Persons', // @translate
+            'source' => 'https://graph.friesland.regiotermen.nl/repositories/friese_thesaurus',
+        ],
+```
+
+The key of the source in the `$types` array should be unique. The last part (`rtf` in this example) is made up. Be aware that this key is used within the definition of resource templates and therefor **MUST NOT** change.
+
+## 3 - Update [README.md](README.md)
+
+The README.md contains a description of the module as well of the list of terminology sources available via this module. The README.md is also the source of the module information page https://omeka.org/s/modules/NdeTermennetwerk/
+
+The (English) name of the new source should be added to the list of this README.md file.
+
+## 3 - Update version in [config/module.ini](config/module.ini)
+
+The file config/module.ini contains the versionnumber of the module. When new terminology sources are added the minor number of the version should be incremented.
+
+## 4 - Update language strings
+
+
+The `// @translate` tag in [src/Service/NdeTermsDataTypeFactory.php](src/Service/NdeTermsDataTypeFactory.php) indicates a new English term which has to be translated.
+
+?? Can the nl_NL.po be directly updated of should `gulp i18n:template` be issued first, or should this be done via [Transifex](https://app.transifex.com/omeka/omeka-s/translate/#nl_NL/module-NdeTermennetwerk)

--- a/AddSource.md
+++ b/AddSource.md
@@ -64,7 +64,7 @@ The `$types` array in the src/Service/NdeTermsDataTypeFactory.php file should be
   ],
 ```
 
-The key of the source in the `$types` array should be unique. The last part (`rtf` in this example) is made up. Be aware that this key is used within the definition of resource templates and therefor **MUST NOT** change.
+The key of the source in the `$types` array should be unique. The last part (`rtf` in this example) is made up. Be aware that this key is used within the definition of resource templates and therefor **MUST NOT** change. For consistency, the label should be prepended with "NDE: ".
 
 ## 3 - Update [config/module.config.php](config/module.config.php)
 

--- a/AddSource.md
+++ b/AddSource.md
@@ -58,25 +58,33 @@ Take note of the English name of the Dataset (to be used as `label`) and the (pe
 The `$types` array in the src/Service/NdeTermsDataTypeFactory.php file should be expanded with an entry like:
 
 ```php
-        'valuesuggest:ndeterms:rtf' => [
-            'label' => 'Regiotermen Fryslân: Persons', // @translate
-            'source' => 'https://graph.friesland.regiotermen.nl/repositories/friese_thesaurus',
-        ],
+  'valuesuggest:ndeterms:rtf' => [
+    'label' => 'Regiotermen Fryslân: Persons', // @translate
+    'source' => 'https://graph.friesland.regiotermen.nl/repositories/friese_thesaurus',
+  ],
 ```
 
 The key of the source in the `$types` array should be unique. The last part (`rtf` in this example) is made up. Be aware that this key is used within the definition of resource templates and therefor **MUST NOT** change.
 
-## 3 - Update [README.md](README.md)
+## 3 - Update [config/module.config.php](config/module.config.php)
+
+Add map the new source by key to `the `Service\NdeTermsDataTypeFactory::class` in the `data_type` => `factories` array, like:
+
+```php
+  'valuesuggest:ndeterms:rtf' => Service\NdeTermsDataTypeFactory::class,
+```
+
+## 4 - Update [README.md](README.md)
 
 The README.md contains a description of the module as well of the list of terminology sources available via this module. The README.md is also the source of the module information page https://omeka.org/s/modules/NdeTermennetwerk/
 
 The (English) name of the new source should be added to the list of this README.md file.
 
-## 3 - Update version in [config/module.ini](config/module.ini)
+## 5 - Update version in [config/module.ini](config/module.ini)
 
 The file config/module.ini contains the versionnumber of the module. When new terminology sources are added the minor number of the version should be incremented.
 
-## 4 - Update language strings
+## 6 - Update language strings
 
 
 The `// @translate` tag in [src/Service/NdeTermsDataTypeFactory.php](src/Service/NdeTermsDataTypeFactory.php) indicates a new English term which has to be translated.

--- a/AddSource.md
+++ b/AddSource.md
@@ -43,15 +43,9 @@ For example, [rtf-personen.jsonld](https://github.com/netwerk-digitaal-erfgoed/n
     }
   ],
   ...
-  "distribution": [
-    {
-      "@id": "https://graph.friesland.regiotermen.nl/repositories/friese_thesaurus",
-      ...
-    }
-  ]
 }
 ```
-Take note of the English name of the Dataset (to be used as `label`) and the (persistent) @id of the distribution of the dataset (to be used as `source`).
+Take note of the English `name` of the Dataset (to be used as `label`) and the (persistent) @id of the Dataset (to be used as `source`).
 
 ## 2 - Update [src/Service/NdeTermsDataTypeFactory.php](src/Service/NdeTermsDataTypeFactory.php)
 
@@ -60,7 +54,7 @@ The `$types` array in the src/Service/NdeTermsDataTypeFactory.php file should be
 ```php
   'valuesuggest:ndeterms:rtf' => [
     'label' => 'Regiotermen Fryslân: Persons', // @translate
-    'source' => 'https://graph.friesland.regiotermen.nl/repositories/friese_thesaurus',
+    'source' => 'https://fryslan.regiotermen.nl/personen',
   ],
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 - GTAA: geographical namess
 - GTAA: names
 - GTAA: subjects
+- GTAA: subjects sound-vision
 - GTAA: person names
 - Homosaurus
 - Iconclass

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 - Muziekschatten: performance mediums
 - Muziekschatten: persons
 - National Monuments Register RCE
+- Regiotermen Fryslân: Persons
 - RKDartists
 - STCN: printers
 - Streets in Gouda

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 
 ### [NDE Termennetwerk](https://termennetwerk.netwerkdigitaalerfgoed.nl/)
 
+- Art & Architecture Thesaurus
 - Art & Architecture Thesaurus - materials
 - Art & Architecture Thesaurus - processes and techniques
 - Art & Architecture Thesaurus - styles and periods

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 - Dutch National Thesaurus for Author Names
 - EuroVoc - thesaurus of the European Union
 - GeoNames: geographical names in the Netherlands, Belgium and Germany
+- GeoNames: global geographical names
 - GTAA: classification
 - GTAA: genres
 - GTAA: geographical namess

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 - Cultural-Historical Thesaurus
 - Cultural-Historical Thesaurus - Materials
 - Cultural-Historical Thesaurus - Styles and periods
-- Dutch thesaurus of author names (NTA)
+- Dutch National Thesaurus for Author Names
 - EuroVoc - thesaurus of the European Union
-- GeoNames: gepgraphical names in the Netherlands, Belgium and Germany
+- GeoNames: geographical names in the Netherlands, Belgium and Germany
 - GTAA: classification
 - GTAA: genres
-- GTAA: geographic names
+- GTAA: geographical namess
 - GTAA: names
 - GTAA: subjects
 - GTAA: person names
 - Homosaurus
 - Iconclass
-- Indian Heritage Thesaurus
-- Muziekweb: genres and styles
-- Muziekweb: persons and groups
+- Dutch East Indies Heritage Thesaurus
+- Music: genres and styles
+- Music: persons and groups
 - Muziekschatten: subjects
 - Muziekschatten: performance mediums
 - Muziekschatten: persons
@@ -37,9 +37,9 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 - Regiotermen Fryslân: Persons
 - RKDartists
 - STCN: printers
-- Streets in Gouda
+- Gouda streets
 - Thesaurus National Museum of World Cultures
-- Thesaurus Second World War Netherlands
+- Thesaurus WW2
 - Wikidata: all entities
 - Wikidata: persons
 - Wikidata: places in the Netherlands and Belgium

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 - Art & Architecture Thesaurus - styles and periods
 - Archaeological Basic Register
 - Adamlink: streets in Amsterdam
+- Adamlink: historical addresses in Amsterdam
 - Biographies Second World War Netherlands
 - Brinkman keyword thesaurus
 - Buildings in Brabant

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 - Muziekschatten: performance mediums
 - Muziekschatten: persons
 - National Monuments Register RCE
+- Persons in Context role thesaurus
+- Persons in Context source types thesaurus
 - Regiotermen Fryslân: Persons
 - RKDartists
 - STCN: printers

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ An [Omeka S](https://omeka.org/s/) module that adds the [Network of Terms](https
 - RKDartists
 - STCN: printers
 - Gouda streets
+- Thesaurus Camp Westerbork
 - Thesaurus National Museum of World Cultures
 - Thesaurus WW2
 - Wikidata: all entities

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -8,6 +8,7 @@ return [
             'valuesuggest:ndeterms:aatpt' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:aatsp' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:abr' => Service\NdeTermsDataTypeFactory::class,
+            'valuesuggest:ndeterms:adamadrs' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:adamlink' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:bcgebouwen' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:btt' => Service\NdeTermsDataTypeFactory::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -43,6 +43,7 @@ return [
             'valuesuggest:ndeterms:tnmw' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:tswwnl' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:ttwn' => Service\NdeTermsDataTypeFactory::class,
+            'valuesuggest:ndeterms:wstb' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:wikiall' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:wikipers' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:wikiplacenlbe' => Service\NdeTermsDataTypeFactory::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -35,6 +35,7 @@ return [
             'valuesuggest:ndeterms:nta' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:rcemon' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:rkdartists' => Service\NdeTermsDataTypeFactory::class,
+            'valuesuggest:ndeterms:rtf' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:stcn' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:tnmw' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:tswwnl' => Service\NdeTermsDataTypeFactory::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -4,6 +4,7 @@ namespace NdeTermennetwerk;
 return [
     'data_types' => [
         'factories' => [
+            'valuesuggest:ndeterms:aat' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:aatm' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:aatpt' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:aatsp' => Service\NdeTermsDataTypeFactory::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -24,6 +24,7 @@ return [
             'valuesuggest:ndeterms:gtaageo' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:gtaanam' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:gtaaond' => Service\NdeTermsDataTypeFactory::class,
+            'valuesuggest:ndeterms:gtaaondbeng' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:gtaaper' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:gtm' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:homosaurus' => Service\NdeTermsDataTypeFactory::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -37,6 +37,8 @@ return [
             'valuesuggest:ndeterms:muzscp' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:muzscu' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:nta' => Service\NdeTermsDataTypeFactory::class,
+            'valuesuggest:ndeterms:picotrole' => Service\NdeTermsDataTypeFactory::class,
+            'valuesuggest:ndeterms:picotsource' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:rcemon' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:rkdartists' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:rtf' => Service\NdeTermsDataTypeFactory::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -18,6 +18,7 @@ return [
             'valuesuggest:ndeterms:chtsp' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:eurovoc' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:geonames' => Service\NdeTermsDataTypeFactory::class,
+            'valuesuggest:ndeterms:geonamesall' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:gtaacla' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:gtaagen' => Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:gtaageo' => Service\NdeTermsDataTypeFactory::class,

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.5"
+version = "1.3.6"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.7"
+version = "1.3.8"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.6"
+version = "1.3.7"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.1"
+version = "1.3.2"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.3"
+version = "1.3.4"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.9"
+version = "1.3.10"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.4"
+version = "1.3.5"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.0"
+version = "1.3.1"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.2"
+version = "1.3.3"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.10"
+version = "1.3.11"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.8"
+version = "1.3.9"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.3.11"
+version = "1.4.0"
 omeka_version_constraint = "^4.0.0"
 name = "NDE Termennetwerk"
 description = "Adds the Network of Terms (Dutch Digital Heritage Network) to the Value Suggest module"

--- a/language/ca_ES.po
+++ b/language/ca_ES.po
@@ -59,8 +59,8 @@ msgid ""
 msgstr "NDE: GeoNames: noms geogràfics als Països Baixos, Bèlgica i Alemanya"
 
 #: src/Service/NdeTermsDataTypeFactory.php:60
-msgid "NDE: streets in Gouda"
-msgstr "NDE: streets in Gouda"
+msgid "NDE: Gouda streets"
+msgstr "NDE: Gouda streets"
 
 #: src/Service/NdeTermsDataTypeFactory.php:64
 msgid "NDE: GTAA: person names"
@@ -75,8 +75,8 @@ msgid "NDE: GTAA: genres"
 msgstr "NDE: GTAA: genres"
 
 #: src/Service/NdeTermsDataTypeFactory.php:76
-msgid "NDE: GTAA: geographic names"
-msgstr "NDE: GTAA: geographic names"
+msgid "NDE: GTAA: geographical names"
+msgstr "NDE: GTAA: geographical names"
 
 #: src/Service/NdeTermsDataTypeFactory.php:80
 msgid "NDE: GTAA: names"
@@ -95,16 +95,16 @@ msgid "NDE: Iconclass"
 msgstr "NDE: Iconclass"
 
 #: src/Service/NdeTermsDataTypeFactory.php:96
-msgid "NDE: Indian Heritage Thesaurus"
-msgstr "NDE: Indian Heritage Thesaurus"
+msgid "NDE: Dutch East Indies Heritage Thesaurus"
+msgstr "NDE: Dutch East Indies Heritage Thesaurus"
 
 #: src/Service/NdeTermsDataTypeFactory.php:100
-msgid "NDE: Muziekweb: genres and styles"
-msgstr "NDE: Muziekweb: genres and styles"
+msgid "NDE: Music: genres and styles"
+msgstr "NDE: Music: genres and styles"
 
 #: src/Service/NdeTermsDataTypeFactory.php:104
-msgid "NDE: Muziekweb: persons and groups"
-msgstr "NDE: Muziekweb: persons and groups"
+msgid "NDE: Music: persons and groups"
+msgstr "NDE: Music: persons and groups"
 
 #: src/Service/NdeTermsDataTypeFactory.php:108
 msgid "NDE: Muziekschatten: subjects"
@@ -135,8 +135,8 @@ msgid "NDE: Thesaurus National Museum of World Cultures"
 msgstr "NDE: Thesaurus National Museum of World Cultures"
 
 #: src/Service/NdeTermsDataTypeFactory.php:136
-msgid "NDE: Thesaurus Second World War Netherlands"
-msgstr "NDE: Thesaurus Second World War Netherlands"
+msgid "NDE: Thesaurus WW2"
+msgstr "NDE: Thesaurus WW2"
 
 #: src/Service/NdeTermsDataTypeFactory.php:140
 msgid "NDE: Biographies Second World War Netherlands"

--- a/language/it.po
+++ b/language/it.po
@@ -59,7 +59,7 @@ msgid ""
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:60
-msgid "NDE: streets in Gouda"
+msgid "NDE: Gouda streets"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:64
@@ -75,7 +75,7 @@ msgid "NDE: GTAA: genres"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:76
-msgid "NDE: GTAA: geographic names"
+msgid "NDE: GTAA: geographical names"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:80
@@ -95,15 +95,15 @@ msgid "NDE: Iconclass"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:96
-msgid "NDE: Indian Heritage Thesaurus"
+msgid "NDE: Dutch East Indies Heritage Thesaurus"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:100
-msgid "NDE: Muziekweb: genres and styles"
+msgid "NDE: Music: genres and styles"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:104
-msgid "NDE: Muziekweb: persons and groups"
+msgid "NDE: Music: persons and groups"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:108
@@ -135,7 +135,7 @@ msgid "NDE: Thesaurus National Museum of World Cultures"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:136
-msgid "NDE: Thesaurus Second World War Netherlands"
+msgid "NDE: Thesaurus WW2"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:140

--- a/language/nl_NL.po
+++ b/language/nl_NL.po
@@ -59,7 +59,7 @@ msgid ""
 msgstr "NDE: Geonames NL, BE en DE"
 
 #: src/Service/NdeTermsDataTypeFactory.php:60
-msgid "NDE: streets in Gouda"
+msgid "NDE: Gouda streets"
 msgstr "NDE: Straten in Gouda"
 
 #: src/Service/NdeTermsDataTypeFactory.php:64
@@ -75,7 +75,7 @@ msgid "NDE: GTAA: genres"
 msgstr "NDE: GTAA - genres"
 
 #: src/Service/NdeTermsDataTypeFactory.php:76
-msgid "NDE: GTAA: geographic names"
+msgid "NDE: GTAA: geographical names"
 msgstr "NDE: GTAA - geografische namen"
 
 #: src/Service/NdeTermsDataTypeFactory.php:80
@@ -95,15 +95,15 @@ msgid "NDE: Iconclass"
 msgstr "NDE: IconClass"
 
 #: src/Service/NdeTermsDataTypeFactory.php:96
-msgid "NDE: Indian Heritage Thesaurus"
+msgid "NDE: Dutch East Indies Heritage Thesaurus"
 msgstr "NDE: Indisch Erfgoed Thesaurus"
 
 #: src/Service/NdeTermsDataTypeFactory.php:100
-msgid "NDE: Muziekweb: genres and styles"
+msgid "NDE: Music: genres and styles"
 msgstr "NDE: Muziekweb - genres en stijlen"
 
 #: src/Service/NdeTermsDataTypeFactory.php:104
-msgid "NDE: Muziekweb: persons and groups"
+msgid "NDE: Music: persons and groups"
 msgstr "NDE: Muziekweb - personen en groepen"
 
 #: src/Service/NdeTermsDataTypeFactory.php:108
@@ -135,7 +135,7 @@ msgid "NDE: Thesaurus National Museum of World Cultures"
 msgstr "NDE: Thesaurus Nationaal Museum van Wereldculturen"
 
 #: src/Service/NdeTermsDataTypeFactory.php:136
-msgid "NDE: Thesaurus Second World War Netherlands"
+msgid "NDE: Thesaurus WW2"
 msgstr "NDE: WO2-thesaurus"
 
 #: src/Service/NdeTermsDataTypeFactory.php:140

--- a/language/template.pot
+++ b/language/template.pot
@@ -51,7 +51,7 @@ msgid ""
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:60
-msgid "NDE: streets in Gouda"
+msgid "NDE: Gouda streets"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:64
@@ -67,7 +67,7 @@ msgid "NDE: GTAA: genres"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:76
-msgid "NDE: GTAA: geographic names"
+msgid "NDE: GTAA: geographical names"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:80
@@ -87,15 +87,15 @@ msgid "NDE: Iconclass"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:96
-msgid "NDE: Indian Heritage Thesaurus"
+msgid "NDE: Dutch East Indies Heritage Thesaurus"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:100
-msgid "NDE: Muziekweb: genres and styles"
+msgid "NDE: Music: genres and styles"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:104
-msgid "NDE: Muziekweb: persons and groups"
+msgid "NDE: Music: persons and groups"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:108
@@ -127,7 +127,7 @@ msgid "NDE: Thesaurus National Museum of World Cultures"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:136
-msgid "NDE: Thesaurus Second World War Netherlands"
+msgid "NDE: Thesaurus WW2"
 msgstr ""
 
 #: src/Service/NdeTermsDataTypeFactory.php:140

--- a/src/DataType/NdeTerms.php
+++ b/src/DataType/NdeTerms.php
@@ -29,7 +29,8 @@ class NdeTerms extends AbstractDataType
     {
         return new NdeTermsSuggest(
             $this->services->get('Omeka\HttpClient'),
-            $this->ndeTermsSource
+            $this->ndeTermsSource,
+            $this->services->get('Omeka\ModuleManager')
         );
     }
 

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -28,6 +28,10 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: Archaeological Basic Register', // @translate
             'source' => 'https://data.cultureelerfgoed.nl/term/id/abr',
         ],
+        'valuesuggest:ndeterms:adamadrs' => [
+            'label' => 'NDE: Adamlink: historical addresses in Amsterdam', // @translate
+            'source' => 'hhttps://adamlink.nl/geo/addresses/start/',
+        ],
         'valuesuggest:ndeterms:adamlink' => [
             'label' => 'NDE: Adamlink: streets in Amsterdam', // @translate
             'source' => 'https://adamlink.nl/geo/streets/list',

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -144,6 +144,10 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: STCN: printers', // @translate
             'source' => 'http://data.bibliotheken.nl/id/dataset/stcn/printers',
         ],
+        'valuesuggest:ndeterms:wstb' => [
+            'label' => 'NDE: Thesaurus Camp Westerbork', // @translate
+            'source' => 'https://data.kampwesterbork.nl/thesaurus',
+        ],
         'valuesuggest:ndeterms:tnmw' => [
             'label' => 'NDE: Thesaurus National Museum of World Cultures', // @translate
             'source' => 'https://data.colonialcollections.nl/nmvw/thesaurus',

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -120,6 +120,10 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: Dutch thesaurus of author names', // @translate
             'source' => 'http://data.bibliotheken.nl/thesp/sparql',
         ],
+        'valuesuggest:ndeterms:rtf' => [
+            'label' => 'NDE: Regiotermen Fryslân: Persons', // @translate
+            'source' => 'https://fryslan.regiotermen.nl/personen',
+        ],
         'valuesuggest:ndeterms:rkdartists' => [
             'label' => 'NDE: RKDartists', // @translate
             'source' => 'https://data.rkd.nl/rkdartists',

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -57,7 +57,7 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'source' => 'https://www.geonames.org#nl-be-de',
         ],
         'valuesuggest:ndeterms:gtm' => [
-            'label' => 'NDE: streets in Gouda', // @translate
+            'label' => 'NDE: Gouda streets', // @translate
             'source' => 'https://www.goudatijdmachine.nl/id/straten',
         ],
         'valuesuggest:ndeterms:gtaaper' => [
@@ -73,7 +73,7 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'source' => 'http://data.beeldengeluid.nl/gtaa/Genre',
         ],
         'valuesuggest:ndeterms:gtaageo' => [
-            'label' => 'NDE: GTAA: geographic names', // @translate
+            'label' => 'NDE: GTAA: geographical names', // @translate
             'source' => 'http://data.beeldengeluid.nl/gtaa/GeografischeNamen',
         ],
         'valuesuggest:ndeterms:gtaanam' => [
@@ -93,15 +93,15 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'source' => 'https://iconclass.org',
         ],
         'valuesuggest:ndeterms:ied' => [
-            'label' => 'NDE: Indian Heritage Thesaurus', // @translate
+            'label' => 'NDE: Dutch East Indies Heritage Thesaurus', // @translate
             'source' => 'https://data.indischherinneringscentrum.nl/ied',
         ],
         'valuesuggest:ndeterms:muzgs' => [
-            'label' => 'NDE: Muziekweb: genres and styles', // @translate
+            'label' => 'NDE: Music: genres and styles', // @translate
             'source' => 'https://data.muziekweb.nl/MuziekwebOrganization/Muziekweb#mw-genresstijlen',
         ],
         'valuesuggest:ndeterms:muzpp' => [
-            'label' => 'NDE: Muziekweb: persons and groups', // @translate
+            'label' => 'NDE: Music: persons and groups', // @translate
             'source' => 'https://data.muziekweb.nl/MuziekwebOrganization/Muziekweb#mw-personengroepen',
         ],
         'valuesuggest:ndeterms:muzsch' => [
@@ -137,7 +137,7 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'source' => 'https://data.colonialcollections.nl/nmvw/thesaurus',
         ],
         'valuesuggest:ndeterms:tswwnl' => [
-            'label' => 'NDE: Thesaurus Second World War Netherlands', // @translate
+            'label' => 'NDE: Thesaurus WW2', // @translate
             'source' => 'https://data.niod.nl/WO2_biografieen',
         ],
         'valuesuggest:ndeterms:ttwn' => [

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -64,6 +64,10 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: GeoNames: geographical names in the Netherlands, Belgium and Germany', // @translate
             'source' => 'https://www.geonames.org#nl-be-de',
         ],
+        'valuesuggest:ndeterms:geonamesall' => [
+            'label' => 'NDE: GeoNames: global geographical names', // @translate
+            'source' => 'https://www.geonames.org',
+        ],
         'valuesuggest:ndeterms:gtm' => [
             'label' => 'NDE: Gouda streets', // @translate
             'source' => 'https://www.goudatijdmachine.nl/id/straten',

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -14,111 +14,111 @@ class NdeTermsDataTypeFactory implements FactoryInterface
     protected $types = [
         'valuesuggest:ndeterms:aatm' => [
             'label' => 'NDE: Art & Architecture Thesaurus - materials', // @translate
-            'source' => 'http://vocab.getty.edu/aat/sparql/materials',
+            'source' => 'http://vocab.getty.edu/aat#materials',
         ],
         'valuesuggest:ndeterms:aatpt' => [
             'label' => 'NDE: Art & Architecture Thesaurus - processes and techniques', // @translate
-            'source' => 'http://vocab.getty.edu/aat/sparql/processes-and-techniques',
+            'source' => 'http://vocab.getty.edu/aat#processes-and-techniques',
         ],
         'valuesuggest:ndeterms:aatsp' => [
             'label' => 'NDE: Art & Architecture Thesaurus - styles and periods', // @translate
-            'source' => 'http://vocab.getty.edu/aat/sparql/styles-and-periods',
+            'source' => 'http://vocab.getty.edu/aat#styles-and-periods',
         ],
         'valuesuggest:ndeterms:abr' => [
             'label' => 'NDE: Archaeological Basic Register', // @translate
-            'source' => 'https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/abr',
+            'source' => 'https://data.cultureelerfgoed.nl/term/id/abr',
         ],
         'valuesuggest:ndeterms:adamlink' => [
             'label' => 'NDE: Adamlink: streets in Amsterdam', // @translate
-            'source' => 'https://druid.datalegend.net/AdamNet/Geography/sparql#streets',
+            'source' => 'https://adamlink.nl/geo/streets/list',
         ],
         'valuesuggest:ndeterms:btt' => [
             'label' => 'NDE: Brinkman keyword thesaurus', // @translate
-            'source' => 'http://data.bibliotheken.nl/thes/brinkman/sparql',
+            'source' => 'http://data.bibliotheken.nl/id/dataset/brinkman',
         ],
         'valuesuggest:ndeterms:cht' => [
             'label' => 'NDE: Cultural-Historical Thesaurus', // @translate
-            'source' => 'https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht',
+            'source' => 'https://data.cultureelerfgoed.nl/term/id/cht',
         ],
         'valuesuggest:ndeterms:chtm' => [
             'label' => 'NDE: Cultural-Historical Thesaurus - Materials', // @translate
-            'source' => 'https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht/materials',
+            'source' => 'https://data.cultureelerfgoed.nl/term/id/cht#materials',
         ],
         'valuesuggest:ndeterms:chtsp' => [
             'label' => 'NDE: Cultural-Historical Thesaurus - Styles and periods', // @translate
-            'source' => 'https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht/styles-and-periods',
+            'source' => 'https://data.cultureelerfgoed.nl/term/id/cht#styles-and-periodes',
         ],
         'valuesuggest:ndeterms:eurovoc' => [
             'label' => 'NDE: EuroVoc - thesaurus of the European Union', // @translate
-            'source' => 'http://publications.europa.eu/webapi/rdf/sparql#eurovoc',
+            'source' => 'https://data.europa.eu/data/datasets/eurovoc',
         ],
         'valuesuggest:ndeterms:geonames' => [
             'label' => 'NDE: GeoNames: geographical names in the Netherlands, Belgium and Germany', // @translate
-            'source' => 'https://demo.netwerkdigitaalerfgoed.nl/geonames',
+            'source' => 'https://www.geonames.org#nl-be-de',
         ],
         'valuesuggest:ndeterms:gtm' => [
             'label' => 'NDE: streets in Gouda', // @translate
-            'source' => 'https://www.goudatijdmachine.nl/id/straten#streets',
+            'source' => 'https://www.goudatijdmachine.nl/id/straten',
         ],
         'valuesuggest:ndeterms:gtaaper' => [
             'label' => 'NDE: GTAA: person names', // @translate
-            'source' => 'https://data.beeldengeluid.nl/id/datadownload/0026',
+            'source' => 'http://data.beeldengeluid.nl/gtaa/Persoonsnamen',
         ],
         'valuesuggest:ndeterms:gtaacla' => [
             'label' => 'NDE: GTAA: classification', // @translate
-            'source' => 'https://data.beeldengeluid.nl/id/datadownload/0027',
+            'source' => 'http://data.beeldengeluid.nl/gtaa/Classificatie',
         ],
         'valuesuggest:ndeterms:gtaagen' => [
             'label' => 'NDE: GTAA: genres', // @translate
-            'source' => 'https://data.beeldengeluid.nl/id/datadownload/0028',
+            'source' => 'http://data.beeldengeluid.nl/gtaa/Genre',
         ],
         'valuesuggest:ndeterms:gtaageo' => [
             'label' => 'NDE: GTAA: geographic names', // @translate
-            'source' => 'https://data.beeldengeluid.nl/id/datadownload/0029',
+            'source' => 'http://data.beeldengeluid.nl/gtaa/GeografischeNamen',
         ],
         'valuesuggest:ndeterms:gtaanam' => [
             'label' => 'NDE: GTAA: names', // @translate
-            'source' => 'https://data.beeldengeluid.nl/id/datadownload/0030',
+            'source' => 'http://data.beeldengeluid.nl/gtaa/Namen',
         ],
         'valuesuggest:ndeterms:gtaaond' => [
             'label' => 'NDE: GTAA: subjects', // @translate
-            'source' => 'https://data.beeldengeluid.nl/id/datadownload/0031',
+            'source' => 'http://data.beeldengeluid.nl/gtaa/Onderwerpen',
         ],
         'valuesuggest:ndeterms:homosaurus' => [
             'label' => 'NDE: Homosaurus', // @translate
-            'source' => 'https://data.ihlia.nl/PoolParty/sparql/homosaurus',
+            'source' => 'https://data.ihlia.nl/homosaurus',
         ],
         'valuesuggest:ndeterms:iconclass' => [
             'label' => 'NDE: Iconclass', // @translate
-            'source' => 'https://iconclass.org/sparql',
+            'source' => 'https://iconclass.org',
         ],
         'valuesuggest:ndeterms:ied' => [
             'label' => 'NDE: Indian Heritage Thesaurus', // @translate
-            'source' => 'https://digitaalerfgoed.poolparty.biz/PoolParty/sparql/ied',
+            'source' => 'https://data.indischherinneringscentrum.nl/ied',
         ],
         'valuesuggest:ndeterms:muzgs' => [
             'label' => 'NDE: Muziekweb: genres and styles', // @translate
-            'source' => 'https://data.muziekweb.nl/MuziekwebOrganization/Muziekweb/sparql/Muziekweb#mw-genresstijlen',
+            'source' => 'https://data.muziekweb.nl/MuziekwebOrganization/Muziekweb#mw-genresstijlen',
         ],
         'valuesuggest:ndeterms:muzpp' => [
             'label' => 'NDE: Muziekweb: persons and groups', // @translate
-            'source' => 'https://data.muziekweb.nl/MuziekwebOrganization/Muziekweb/sparql/Muziekweb#mw-personengroepen',
+            'source' => 'https://data.muziekweb.nl/MuziekwebOrganization/Muziekweb#mw-personengroepen',
         ],
         'valuesuggest:ndeterms:muzsch' => [
             'label' => 'NDE: Muziekschatten: subjects', // @translate
-            'source' => 'https://data.muziekschatten.nl/sparql/#onderwerpen',
+            'source' => 'https://data.muziekschatten.nl/#onderwerpen',
         ],
         'valuesuggest:ndeterms:muzscp' => [
             'label' => 'NDE: Muziekschatten: persons', // @translate
-            'source' => 'https://data.muziekschatten.nl/sparql/#personen',
+            'source' => 'https://data.muziekschatten.nl/#personen',
         ],
         'valuesuggest:ndeterms:muzscu' => [
             'label' => 'NDE: Muziekschatten: performance mediums', // @translate
-            'source' => 'https://data.muziekschatten.nl/sparql/#uitvoeringsmedium',
+            'source' => 'https://data.muziekschatten.nl/som/Uitvoeringsmedium',
         ],
         'valuesuggest:ndeterms:nta' => [
             'label' => 'NDE: Dutch thesaurus of author names', // @translate
-            'source' => 'http://data.bibliotheken.nl/thesp/sparql',
+            'source' => 'http://data.bibliotheken.nl/id/dataset/persons',
         ],
         'valuesuggest:ndeterms:rtf' => [
             'label' => 'NDE: Regiotermen Fryslân: Persons', // @translate
@@ -130,11 +130,11 @@ class NdeTermsDataTypeFactory implements FactoryInterface
         ],
         'valuesuggest:ndeterms:stcn' => [
             'label' => 'NDE: STCN: printers', // @translate
-            'source' => 'http://data.bibliotheken.nl/thes/drukkers/sparql',
+            'source' => 'http://data.bibliotheken.nl/id/dataset/stcn/printers',
         ],
         'valuesuggest:ndeterms:tnmw' => [
             'label' => 'NDE: Thesaurus National Museum of World Cultures', // @translate
-            'source' => 'https://data.netwerkdigitaalerfgoed.nl/NMVW/thesaurus/sparql',
+            'source' => 'https://data.colonialcollections.nl/nmvw/thesaurus',
         ],
         'valuesuggest:ndeterms:tswwnl' => [
             'label' => 'NDE: Thesaurus Second World War Netherlands', // @translate
@@ -142,7 +142,7 @@ class NdeTermsDataTypeFactory implements FactoryInterface
         ],
         'valuesuggest:ndeterms:ttwn' => [
             'label' => 'NDE: WW2 biographies', // @translate
-            'source' => 'https://data.niod.nl/PoolParty/sparql/WO2_Thesaurus',
+            'source' => 'https://data.niod.nl/WO2_Thesaurus',
         ],
         'valuesuggest:ndeterms:wikiall' => [
             'label' => 'NDE: Wikidata: all entities', // @translate
@@ -150,23 +150,23 @@ class NdeTermsDataTypeFactory implements FactoryInterface
         ],
         'valuesuggest:ndeterms:wikipers' => [
             'label' => 'NDE: Wikidata: persons', // @translate
-            'source' => 'https://query.wikidata.org/sparql#entities-persons',
+            'source' => 'https://www.wikidata.org#entities-persons',
         ],
         'valuesuggest:ndeterms:wikiplacenlbe' => [
             'label' => 'NDE: Wikidata: places in the Netherlands and Belgium', // @translate
-            'source' => 'https://query.wikidata.org/sparql#entities-places',
+            'source' => 'https://www.wikidata.org#entities-places',
         ],
         'valuesuggest:ndeterms:wikistrnl' => [
             'label' => 'NDE: Wikidata: streets in the Netherlands', // @translate
-            'source' => 'https://query.wikidata.org/sparql#entities-streets',
+            'source' => 'https://www.wikidata.org#entities-streets',
         ],
         'valuesuggest:ndeterms:bcgebouwen' => [
             'label' => 'NDE: Buildings in Brabant', // @translate
-            'source' => 'https://data.brabantcloud.nl/gebouwen/query/',
+            'source' => 'https://data.brabantcloud.nl/gebouwen',
         ],
         'valuesuggest:ndeterms:kolverleden' => [
             'label' => 'NDE: Colonial Past', // @translate
-            'source' => 'https://data.cultureelerfgoed.nl/PoolParty/sparql/koloniaalverleden',
+            'source' => 'https://data.cultureelerfgoed.nl/koloniaalverleden/',
         ],
         'valuesuggest:ndeterms:rcemon' => [
             'label' => 'NDE: National Monuments Register RCE', // @translate

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -138,10 +138,10 @@ class NdeTermsDataTypeFactory implements FactoryInterface
         ],
         'valuesuggest:ndeterms:tswwnl' => [
             'label' => 'NDE: Thesaurus Second World War Netherlands', // @translate
-            'source' => 'https://data.niod.nl/PoolParty/sparql/WO2_Thesaurus',
+            'source' => 'https://data.niod.nl/WO2_biografieen',
         ],
         'valuesuggest:ndeterms:ttwn' => [
-            'label' => 'NDE: Biographies Second World War Netherlands', // @translate
+            'label' => 'NDE: WW2 biographies', // @translate
             'source' => 'https://data.niod.nl/PoolParty/sparql/WO2_Thesaurus',
         ],
         'valuesuggest:ndeterms:wikiall' => [

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -12,6 +12,10 @@ use NdeTermennetwerk\DataType\NdeTerms;
 class NdeTermsDataTypeFactory implements FactoryInterface
 {
     protected $types = [
+        'valuesuggest:ndeterms:aat' => [
+            'label' => 'NDE: Art & Architecture Thesaurus', // @translate
+            'source' => 'http://vocab.getty.edu/aat',
+        ],
         'valuesuggest:ndeterms:aatm' => [
             'label' => 'NDE: Art & Architecture Thesaurus - materials', // @translate
             'source' => 'http://vocab.getty.edu/aat#materials',

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -136,6 +136,14 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: Dutch thesaurus of author names', // @translate
             'source' => 'http://data.bibliotheken.nl/id/dataset/persons',
         ],
+        'valuesuggest:ndeterms:picotrole' => [
+            'label' => 'NDE: Persons in Context role thesaurus', // @translate
+            'source' => 'https://terms.personsincontext.org/ThesaurusHistorischePersoonsgegevens/44',
+        ],
+        'valuesuggest:ndeterms:picotsource' => [
+            'label' => 'NDE: Persons in Context source types thesaurus', // @translate
+            'source' => 'https://terms.personsincontext.org/ThesaurusHistorischePersoonsgegevens/523',
+        ],
         'valuesuggest:ndeterms:rtf' => [
             'label' => 'NDE: Regiotermen Fryslân: Persons', // @translate
             'source' => 'https://fryslan.regiotermen.nl/personen',

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -96,6 +96,10 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: GTAA: subjects', // @translate
             'source' => 'http://data.beeldengeluid.nl/gtaa/Onderwerpen',
         ],
+        'valuesuggest:ndeterms:gtaaondbeng' => [
+            'label' => 'NDE: GTAA: subjects sound-vision', // @translate
+            'source' => 'http://data.beeldengeluid.nl/gtaa/OnderwerpenBenG',
+        ],
         'valuesuggest:ndeterms:homosaurus' => [
             'label' => 'NDE: Homosaurus', // @translate
             'source' => 'https://data.ihlia.nl/homosaurus',

--- a/src/Suggester/NdeTermsSuggest.php
+++ b/src/Suggester/NdeTermsSuggest.php
@@ -3,6 +3,7 @@ namespace NdeTermennetwerk\Suggester;
 
 use Laminas\Http\Client;
 use ValueSuggest\Suggester\SuggesterInterface;
+use Omeka\Module\Manager as ModuleManager;
 
 /**
  * Implementation following the structure of other Suggester classes, mainly
@@ -20,10 +21,16 @@ class NdeTermsSuggest implements SuggesterInterface
      */
     protected $source;
 
-    public function __construct(Client $client, $source)
+    /**
+     * @var ModuleManager
+     */
+    protected $moduleManager;
+
+    public function __construct(Client $client, $source, ModuleManager $moduleManager)
     {
         $this->client = $client;
         $this->source = $source;
+        $this->moduleManager = $moduleManager;
     }
 
     /**
@@ -44,7 +51,9 @@ class NdeTermsSuggest implements SuggesterInterface
         if (strlen($query) < 4) {
             return [];
         }
-        $agent = "Omeka S ValueSuggest";
+        $module = $this->moduleManager->getModule('NdeTermennetwerk');
+        $version = $module ? $module->getIni('version') : '1.0.0';
+        $agent = "Omeka S ValueSuggest NdeTermennetwerk/{$version}";
         $endpoint = "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphql";
         $graphqlQuery = $this->buildQuery($query, $this->source);
         $result = $this->graphqlExecute($endpoint, $agent, $graphqlQuery);


### PR DESCRIPTION
- Added source NDE: Regiotermen Fryslân: Persons 
- Added source NDE: Adamlink: historical addresses in Amsterdam 
- Added source NDE: add Art & Architecture Thesaurus Getty 
- Added source NDE: GeoNames: global geographical names 
- Added source NDE: Thesaurus Camp Westerbork 
- Added source NDE: GTAA: subjects sound-vision 
- Added source NDE: Persons in Context thesauri 

- Corrected source & label of existing WW2 biographies 
- Synchronized source names with catalog of Network of Terms
- Changed distribution URIs to dataset URIs (= non-breaking change, just future-proofing)
- Add module version number to user agent header 
- Increased version number for release

- Added AddSource.md to document how to add additional sources (documentation)

@jimsafley strings were added and changed, so translations need to be added to Transifex and translated (minimally into Dutch),  preferable prior to merge & release. See also my question about the procedure to follow on https://forum.omeka.org/t/module-release-process-adding-translations-to-module/28040

